### PR TITLE
Add basic Next.js landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Ondev-Systems
-OnDev Systems Official Website 
+
+Landing page oficial de OnDev Systems construida con Next.js y Tailwind CSS.
+
+## Scripts
+
+```bash
+npm run dev     # Ejecuta la aplicación en modo desarrollo
+npm run build   # Compila la aplicación para producción
+npm start       # Inicia la aplicación compilada
+```

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,0 +1,20 @@
+import './globals.css'
+import Navbar from '../components/Navbar'
+import Footer from '../components/Footer'
+
+export const metadata = {
+  title: 'OnDev Systems',
+  description: 'Soluciones digitales para tu negocio',
+}
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="es">
+      <body className="pt-16">
+        <Navbar />
+        {children}
+        <Footer />
+      </body>
+    </html>
+  )
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,17 @@
+import Hero from '../components/Hero'
+import Services from '../components/Services'
+import Portfolio from '../components/Portfolio'
+import About from '../components/About'
+import Contact from '../components/Contact'
+
+export default function Home() {
+  return (
+    <>
+      <Hero />
+      <Services />
+      <Portfolio />
+      <About />
+      <Contact />
+    </>
+  )
+}

--- a/components/About.js
+++ b/components/About.js
@@ -1,0 +1,10 @@
+export default function About() {
+  return (
+    <section id="nosotros" className="py-20 bg-gray-100">
+      <div className="container mx-auto text-center">
+        <h2 className="text-3xl font-bold mb-4">Sobre nosotros</h2>
+        <p className="max-w-2xl mx-auto">Somos un equipo apasionado por la tecnología y la innovación. Nuestra misión es impulsar negocios mediante soluciones digitales personalizadas.</p>
+      </div>
+    </section>
+  )
+}

--- a/components/Contact.js
+++ b/components/Contact.js
@@ -1,0 +1,15 @@
+export default function Contact() {
+  return (
+    <section id="contacto" className="py-20">
+      <div className="container mx-auto">
+        <h2 className="text-3xl font-bold text-center mb-8">Contacto</h2>
+        <form className="max-w-lg mx-auto space-y-4">
+          <input type="text" placeholder="Nombre" className="w-full p-3 border rounded" />
+          <input type="email" placeholder="Correo" className="w-full p-3 border rounded" />
+          <textarea placeholder="Mensaje" className="w-full p-3 border rounded h-32" />
+          <button type="submit" className="bg-blue-600 text-white px-6 py-3 rounded w-full">Enviar</button>
+        </form>
+      </div>
+    </section>
+  )
+}

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,0 +1,16 @@
+export default function Footer() {
+  return (
+    <footer className="bg-gray-800 text-gray-300 py-8">
+      <div className="container mx-auto flex flex-col md:flex-row justify-between items-center">
+        <p>&copy; {new Date().getFullYear()} OnDev Systems</p>
+        <div className="flex space-x-4">
+          <a href="#inicio" className="hover:text-white">Inicio</a>
+          <a href="#servicios" className="hover:text-white">Servicios</a>
+          <a href="#portafolio" className="hover:text-white">Portafolio</a>
+          <a href="#nosotros" className="hover:text-white">Nosotros</a>
+          <a href="#contacto" className="hover:text-white">Contacto</a>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/components/Hero.js
+++ b/components/Hero.js
@@ -1,0 +1,11 @@
+export default function Hero() {
+  return (
+    <section id="inicio" className="bg-gradient-to-r from-blue-500 to-pink-500 py-24">
+      <div className="container mx-auto text-center text-white">
+        <h1 className="text-5xl font-bold mb-4">Impulsa tu negocio con soluciones digitales</h1>
+        <p className="text-xl mb-8">Desarrollo web, integración de IA y marketing digital</p>
+        <a href="#contacto" className="bg-white text-blue-600 font-semibold px-6 py-3 rounded">Contáctanos</a>
+      </div>
+    </section>
+  )
+}

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+
+export default function Navbar() {
+  return (
+    <nav className="fixed top-0 left-0 w-full bg-white shadow z-10">
+      <div className="container mx-auto flex justify-between items-center p-4">
+        <Link href="/" className="text-xl font-bold">OnDev Systems</Link>
+        <ul className="hidden md:flex space-x-4">
+          <li>
+            <a href="#inicio" className="hover:text-blue-600">Inicio</a>
+          </li>
+          <li>
+            <a href="#servicios" className="hover:text-blue-600">Servicios</a>
+          </li>
+          <li>
+            <a href="#portafolio" className="hover:text-blue-600">Portafolio</a>
+          </li>
+          <li>
+            <a href="#nosotros" className="hover:text-blue-600">Nosotros</a>
+          </li>
+          <li>
+            <a href="#contacto" className="hover:text-blue-600">Contacto</a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  )
+}

--- a/components/Portfolio.js
+++ b/components/Portfolio.js
@@ -1,0 +1,23 @@
+const projects = [
+  { title: 'Proyecto 1', description: 'Descripción breve del proyecto' },
+  { title: 'Proyecto 2', description: 'Descripción breve del proyecto' },
+  { title: 'Proyecto 3', description: 'Descripción breve del proyecto' }
+]
+
+export default function Portfolio() {
+  return (
+    <section id="portafolio" className="py-20">
+      <div className="container mx-auto text-center">
+        <h2 className="text-3xl font-bold mb-8">Portafolio</h2>
+        <div className="grid gap-8 md:grid-cols-3">
+          {projects.map((item, idx) => (
+            <div key={idx} className="bg-white p-6 rounded shadow">
+              <h3 className="text-xl font-semibold mb-2">{item.title}</h3>
+              <p>{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/Services.js
+++ b/components/Services.js
@@ -1,0 +1,23 @@
+const data = [
+  { title: 'Desarrollo Web', description: 'Sitios modernos y optimizados.' },
+  { title: 'Integración de IA', description: 'Automatiza y mejora procesos.' },
+  { title: 'Marketing Digital', description: 'Estrategias para aumentar tu alcance.' }
+]
+
+export default function Services() {
+  return (
+    <section id="servicios" className="py-20 bg-gray-100">
+      <div className="container mx-auto text-center">
+        <h2 className="text-3xl font-bold mb-8">Servicios</h2>
+        <div className="grid gap-8 md:grid-cols-3">
+          {data.map((item, idx) => (
+            <div key={idx} className="bg-white p-6 rounded shadow">
+              <h3 className="text-xl font-semibold mb-2">{item.title}</h3>
+              <p>{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ondev-systems",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.3.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 13 project using the app router
- add Tailwind CSS configuration
- implement reusable components (Navbar, Hero, Services, Portfolio, About, Contact, Footer)
- create main layout and page using the components
- document project scripts in Spanish

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d87d8bad0832d8db705b839b22edc